### PR TITLE
allow options for excluding padding

### DIFF
--- a/lib/thirty-two/thirty-two.js
+++ b/lib/thirty-two/thirty-two.js
@@ -40,7 +40,7 @@ function quintetCount(buff) {
     return buff.length % 5 === 0 ? quintets: quintets + 1;
 }
 
-exports.encode = function(plain) {
+exports.encode = function(plain, options) {
     if(!Buffer.isBuffer(plain)){
     	plain = new Buffer(plain);
     }
@@ -70,9 +70,10 @@ exports.encode = function(plain) {
         encoded[j] = charTable.charCodeAt(digit);
         j++;
     }
-
-    for(i = j; i < encoded.length; i++) {
-        encoded[i] = 0x3d; //'='.charCodeAt(0)
+    if(!(options && options.excludePadding)) {
+        for(i = j; i < encoded.length; i++) {
+            encoded[i] = 0x3d; //'='.charCodeAt(0)
+        }
     }
 
     return encoded;

--- a/spec/thirty-two_spec.js
+++ b/spec/thirty-two_spec.js
@@ -60,4 +60,14 @@ describe('thirty-two', function() {
     	expect(base32.encode(new Buffer("f61e1f998d69151de8334dbe753ab17ae831c13849a6aecd95d0a4e5dc25", 'hex')).toString()).toBe('6YPB7GMNNEKR32BTJW7HKOVRPLUDDQJYJGTK5TMV2CSOLXBF');
     	expect(base32.decode('6YPB7GMNNEKR32BTJW7HKOVRPLUDDQJYJGTK5TMV2CSOLXBF').toString('hex')).toBe('f61e1f998d69151de8334dbe753ab17ae831c13849a6aecd95d0a4e5dc25');
     });
+	
+    it('should encode without padding', function() {
+	var options = {excludePadding: true}
+    	expect(base32.encode('a', options).toString()).toBe('ME');
+        expect(base32.encode('be', options).toString()).toBe('MJSQ');
+        expect(base32.encode('bee', options).toString()).toBe('MJSWK');
+        expect(base32.encode('beer', options).toString()).toBe('MJSWK4Q');
+        expect(base32.encode('beers', options).toString()).toBe('MJSWK4TT');
+        expect(base32.encode('beers 1', options).toString()).toBe('MJSWK4TTEAYQ');
+    });
 });


### PR DESCRIPTION
This is useful for applications such as Google Authenticator which for their iOS app strictly checks against padded secret keys.